### PR TITLE
Add Pydantic Settings

### DIFF
--- a/karman/config.py
+++ b/karman/config.py
@@ -1,12 +1,128 @@
-# FIXME: This is currently a workaround. Instead of hardcoding these values we
-#  should implement a way of loading configuration data from the environment or
-#  a config file.
-class AppConfig:
-    name = "Karman API"
-    debug = True
+__all__ = ["settings"]
 
-    authorize_endpoint = "authorize"
-    token_endpoint = "token"
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple, Union
+
+from pydantic import BaseSettings, Extra, Field
+from pydantic.env_settings import SettingsSourceCallable
+
+ENV_PREFIX = os.getenv("KARMAN_ENV_PREFIX", "KARMAN_")
+ENV_FILENAME = os.getenv(f"{ENV_PREFIX}ENV_FILE", ".env")
+ENV_FILE_ENCODING = os.getenv(f"{ENV_PREFIX}ENV_ENCODING")
+SECRETS_DIR = os.getenv(f"{ENV_PREFIX}SECRETS_DIR", "/run/secrets")
+JSON_FILENAME = os.getenv(f"{ENV_PREFIX}CONFIG", "config.json")
+JSON_FILE_ENCODING = os.getenv(f"{ENV_PREFIX}CONFIG_ENCODING")
 
 
-app_config = AppConfig()
+class JsonSettingsSource:
+    """
+    A simple configuration source reading from a JSON file.
+    """
+
+    __slots__ = ("json_file", "json_file_encoding")
+
+    def __init__(
+        self,
+        json_file: Union[Path, str, None] = None,
+        json_file_encoding: Optional[str] = None,
+    ):
+        self.json_file = json_file
+        self.json_file_encoding = json_file_encoding
+
+    def __call__(self, settings: BaseSettings) -> Dict[str, Any]:
+        if self.json_file is None:
+            return {}
+        file = Path(self.json_file).expanduser()
+        if file.exists():
+            return json.loads(file.read_text(self.json_file_encoding))  # type: ignore
+        else:
+            return {}
+
+
+class Settings(BaseSettings):
+    """
+    The global settings for the Karman API backend.
+
+    Using the settings
+    ==================
+    In your code you can use ``karman.config.settings``, an already initialized object
+    containing the actual settings values. Use it like so:
+
+    >>> settings.app_name
+    'Karman API'
+
+    Configuration sources
+    =====================
+    The ``Settings`` class reads configuration values from three different places. In
+    increasing order of precedence:
+
+    0. (Settings defaults)
+    1. A .env file
+    2. Environment variables
+    3. Secrets folder
+    4. A JSON configuration file
+
+    Chosing Config Sources
+    ======================
+
+    The configuration sources themselves can be configured via the environment:
+
+    ``KARMAN_ENV_PREFIX``
+        A prefix for **all** other environment variables used for configuration.
+        Default: ``KARMAN_``
+    ``{prefix}ENV_FILE`` and ``{prefix}ENV_FILE_ENCODING``
+        The path and encoding of a .env file from which additional configuration
+        variables will be loaded. Default: ``.env``
+    ``{prefix}SECRETS_DIR``
+        A directory containing files that are named like the configuration values (with
+        the configured prefix). The content of the files is used as configuration value.
+    ``{prefix}CONFIG`` and ``{prefix}CONFIG_ENCODING``
+        The path and encoding of a JSON file containing configuration values.
+        Default: ``config.json``
+    """
+
+    app_name: str = Field(
+        "Karman API",
+        description="The name of the application. This value may be visible in the UI.",
+    )
+    debug: bool = Field(
+        True,
+        title="Enable Debug Mode",
+        description="Enables or disables the debug mode. The debug mode includes some "
+        "additional checks that may impact performance. Also it may display sensitive "
+        "debug information when errors occur.",
+    )
+
+    class Config:
+        allow_population_by_field_name = True
+        validate_all = True
+        validate_assignment = True
+        allow_mutation = False
+        extra = Extra.forbid
+
+        env_prefix = ENV_PREFIX
+        env_nested_delimiter = "__"
+        env_file = ENV_FILENAME
+        env_file_encoding = ENV_FILE_ENCODING
+        json_file = JSON_FILENAME
+        json_file_encoding = JSON_FILE_ENCODING
+        secrets_dir = SECRETS_DIR if Path(SECRETS_DIR).exists() else None
+
+        @classmethod
+        def customise_sources(
+            cls,
+            init_settings: SettingsSourceCallable,
+            env_settings: SettingsSourceCallable,
+            file_secret_settings: SettingsSourceCallable,
+        ) -> Tuple[SettingsSourceCallable, ...]:
+            return (
+                init_settings,
+                JsonSettingsSource(cls.json_file, cls.json_file_encoding),
+                file_secret_settings,
+                env_settings,
+            )
+
+
+settings = Settings()

--- a/karman/main.py
+++ b/karman/main.py
@@ -3,7 +3,7 @@ __all__ = ["app", "v1"]
 from fastapi import APIRouter, FastAPI
 from starlette.responses import RedirectResponse
 
-from karman.config import app_config
+from karman.config import settings
 from karman.routes import auth, songs
 from karman.util.openapi import remove_body_schemas
 from karman.versioning import select_routes, strict_version_selector
@@ -17,17 +17,17 @@ v1 = FastAPI(
     version="1.0",
     license_info={"name": "MIT", "url": "https://opensource.org/licenses/MIT"},
     openapi_url="/openapi.json",
-    debug=app_config.debug,
+    debug=settings.debug,
 )
 select_routes(api, v1, strict_version_selector(1))
 remove_body_schemas(v1)
 
 app = FastAPI(
-    title=app_config.name,
+    title=settings.app_name,
     version="0.1",
     license_info={"name": "MIT", "url": "https://opensource.org/licenses/MIT"},
     openapi_url="/openapi.json",
-    debug=app_config.debug,
+    debug=settings.debug,
 )
 app.mount("/v1", v1)
 

--- a/karman/oauth.py
+++ b/karman/oauth.py
@@ -4,8 +4,6 @@ from typing import Dict
 
 from fastapi.security import OAuth2PasswordBearer
 
-from karman.config import app_config
-
 
 class Scope(str, Enum):
     @classmethod
@@ -27,9 +25,12 @@ class Scope(str, Enum):
     # TODO: Add more scopes
 
 
+token_url = "token"
+authorize_url = "authorize"
+
 oauth2_password_scheme = OAuth2PasswordBearer(
     scheme_name="Password Login",
     description="Authenticate against the local Karman user database.",
-    tokenUrl=f"{app_config.token_endpoint}",
+    tokenUrl=f"{token_url}",
     scopes=Scope.all(),
 )

--- a/karman/routes/auth.py
+++ b/karman/routes/auth.py
@@ -3,7 +3,7 @@ from fastapi.routing import APIRoute
 from starlette.responses import RedirectResponse
 from starlette.status import HTTP_400_BAD_REQUEST, HTTP_401_UNAUTHORIZED
 
-from karman.config import app_config
+from karman import oauth
 from karman.schemas.auth import (
     OAuth2AuthorizationRequest,
     OAuth2ErrorResponse,
@@ -33,7 +33,7 @@ router = APIRouter(
 # this API.
 @version(1)
 @router.post(
-    f"/{app_config.token_endpoint}",
+    f"/{oauth.token_url}",
     summary="Login with Username and Password",
     response_model=OAuth2TokenResponse,
     response_description="The response to a successful request contains an "
@@ -72,7 +72,7 @@ def authorize_callback(
 # this API.
 @version(1)
 @router.get(
-    f"/{app_config.authorize_endpoint}",
+    f"/{oauth.authorize_url}",
     summary="Login with an External IdP",
     response_class=RedirectResponse,
     response_description="You will be redirected to the IdP's authentication pages.",

--- a/karman/schemas/auth.py
+++ b/karman/schemas/auth.py
@@ -5,8 +5,8 @@ from typing import Optional
 from fastapi import Form, Query
 from pydantic import BaseModel, Field, HttpUrl
 
-from karman.config import app_config
-from karman.security import Scope
+from karman.config import settings
+from karman.oauth import Scope
 
 OAuth2Token = str
 
@@ -174,8 +174,8 @@ class OAuth2TokenResponse(BaseModel):
     )
 
     class Config:
-        validate_all = app_config.debug
-        validate_assignment = app_config.debug
+        validate_all = settings.debug
+        validate_assignment = settings.debug
 
 
 class OAuth2Error(str, Enum):
@@ -209,5 +209,5 @@ class OAuth2ErrorResponse(BaseModel):
     )
 
     class Config:
-        validate_all = app_config.debug
-        validate_assignment = app_config.debug
+        validate_all = settings.debug
+        validate_assignment = settings.debug

--- a/karman/schemas/base.py
+++ b/karman/schemas/base.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from karman.config import app_config
+from karman.config import settings
 
 
 def to_camel_case(string: str) -> str:
@@ -21,7 +21,7 @@ class BaseSchema(BaseModel):
 
     class Config:
         # Get some extra performance in production by disabling validations
-        validate_all = app_config.debug
-        validate_assignment = app_config.debug
+        validate_all = settings.debug
+        validate_assignment = settings.debug
         allow_population_by_field_name = True
         alias_generator = to_camel_case

--- a/poetry.lock
+++ b/poetry.lock
@@ -150,13 +150,13 @@ pydantic = ">=1.7.2"
 
 [package.extras]
 gino = ["gino[starlette] (>=1.0.1)", "SQLAlchemy (>=1.3.20)"]
-all = ["gino[starlette] (>=1.0.1)", "SQLAlchemy (>=1.3.20)", "databases[sqlite,mysql,postgresql] (>=0.4.0)", "orm (>=0.1.5)", "tortoise-orm[asyncpg,aiosqlite,aiomysql] (>=0.16.18,<0.18.0)", "asyncpg (>=0.24.0)", "ormar (>=0.10.5)", "Django (<3.3.0)", "piccolo (>=0.29,<0.35)", "motor (>=2.5.1,<3.0.0)"]
+all = ["gino[starlette] (>=1.0.1)", "SQLAlchemy (>=1.3.20)", "databases[mysql,postgresql,sqlite] (>=0.4.0)", "orm (>=0.1.5)", "tortoise-orm[aiosqlite,asyncpg,aiomysql] (>=0.16.18,<0.18.0)", "asyncpg (>=0.24.0)", "ormar (>=0.10.5)", "Django (<3.3.0)", "piccolo (>=0.29,<0.35)", "motor (>=2.5.1,<3.0.0)"]
 sqlalchemy = ["SQLAlchemy (>=1.3.20)"]
 asyncpg = ["SQLAlchemy (>=1.3.20)", "asyncpg (>=0.24.0)"]
-databases = ["databases[sqlite,mysql,postgresql] (>=0.4.0)"]
-orm = ["databases[sqlite,mysql,postgresql] (>=0.4.0)", "orm (>=0.1.5)", "typesystem (>=0.2.0,<0.3.0)"]
-django = ["databases[sqlite,mysql,postgresql] (>=0.4.0)", "Django (<3.3.0)"]
-tortoise = ["tortoise-orm[asyncpg,aiosqlite,aiomysql] (>=0.16.18,<0.18.0)"]
+databases = ["databases[mysql,postgresql,sqlite] (>=0.4.0)"]
+orm = ["databases[mysql,postgresql,sqlite] (>=0.4.0)", "orm (>=0.1.5)", "typesystem (>=0.2.0,<0.3.0)"]
+django = ["databases[mysql,postgresql,sqlite] (>=0.4.0)", "Django (<3.3.0)"]
+tortoise = ["tortoise-orm[aiosqlite,asyncpg,aiomysql] (>=0.16.18,<0.18.0)"]
 ormar = ["ormar (>=0.10.5)"]
 piccolo = ["piccolo (>=0.29,<0.35)"]
 motor = ["motor (>=2.5.1,<3.0.0)"]
@@ -262,16 +262,16 @@ python-versions = "*"
 
 [[package]]
 name = "mypy"
-version = "0.920"
+version = "0.930"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-mypy-extensions = ">=0.4.3,<0.5.0"
-tomli = ">=1.1.0,<3.0.0"
-typing-extensions = ">=3.7.4"
+mypy-extensions = ">=0.4.3"
+tomli = ">=1.1.0"
+typing-extensions = ">=3.10"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
@@ -314,11 +314,11 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
 name = "platformdirs"
-version = "2.4.0"
+version = "2.4.1"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.extras]
 docs = ["Sphinx (>=4)", "furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)"]
@@ -469,7 +469,7 @@ name = "python-dotenv"
 version = "0.19.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 category = "main"
-optional = true
+optional = false
 python-versions = ">=3.5"
 
 [package.extras]
@@ -620,7 +620,7 @@ uvicorn = ["uvicorn"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "5dca0e313f5bf36d56831525bd8d958165fa4512558cd6fc1e8243ec99219267"
+content-hash = "ed1908d09111f7b1a5bc161309cb425e6b00bf32b41fa017980116e690e09fbb"
 
 [metadata.files]
 anyio = [
@@ -771,26 +771,26 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mypy = [
-    {file = "mypy-0.920-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:41f3575b20714171c832d8f6c7aaaa0d499c9a2d1b8adaaf837b4c9065c38540"},
-    {file = "mypy-0.920-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:431be889ffc8d9681813a45575c42e341c19467cbfa6dd09bf41467631feb530"},
-    {file = "mypy-0.920-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f8b2059f73878e92eff7ed11a03515d6572f4338a882dd7547b5f7dd242118e6"},
-    {file = "mypy-0.920-cp310-cp310-win_amd64.whl", hash = "sha256:9cd316e9705555ca6a50670ba5fb0084d756d1d8cb1697c83820b1456b0bc5f3"},
-    {file = "mypy-0.920-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e091fe58b4475b3504dc7c3022ff7f4af2f9e9ddf7182047111759ed0973bbde"},
-    {file = "mypy-0.920-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98b4f91a75fed2e4c6339e9047aba95968d3a7c4b91e92ab9dc62c0c583564f4"},
-    {file = "mypy-0.920-cp36-cp36m-win_amd64.whl", hash = "sha256:562a0e335222d5bbf5162b554c3afe3745b495d67c7fe6f8b0d1b5bace0c1eeb"},
-    {file = "mypy-0.920-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:618e677aabd21f30670bffb39a885a967337f5b112c6fb7c79375e6dced605d6"},
-    {file = "mypy-0.920-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40cb062f1b7ff4cd6e897a89d8ddc48c6ad7f326b5277c93a8c559564cc1551c"},
-    {file = "mypy-0.920-cp37-cp37m-win_amd64.whl", hash = "sha256:69b5a835b12fdbfeed84ef31152d41343d32ccb2b345256d8682324409164330"},
-    {file = "mypy-0.920-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:993c2e52ea9570e6e872296c046c946377b9f5e89eeb7afea2a1524cf6e50b27"},
-    {file = "mypy-0.920-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:df0fec878ccfcb2d1d2306ba31aa757848f681e7bbed443318d9bbd4b0d0fe9a"},
-    {file = "mypy-0.920-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:331a81d2c9bf1be25317260a073b41f4584cd11701a7c14facef0aa5a005e843"},
-    {file = "mypy-0.920-cp38-cp38-win_amd64.whl", hash = "sha256:ffb1e57ec49a30e3c0ebcfdc910ae4aceb7afb649310b7355509df6b15bd75f6"},
-    {file = "mypy-0.920-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:31895b0b3060baf15bf76e789d94722c026f673b34b774bba9e8772295edccff"},
-    {file = "mypy-0.920-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:140174e872d20d4768124a089b9f9fc83abd6a349b7f8cc6276bc344eb598922"},
-    {file = "mypy-0.920-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:13b3c110309b53f5a62aa1b360f598124be33a42563b790a2a9efaacac99f1fc"},
-    {file = "mypy-0.920-cp39-cp39-win_amd64.whl", hash = "sha256:82e6c15675264e923b60a11d6eb8f90665504352e68edfbb4a79aac7a04caddd"},
-    {file = "mypy-0.920-py3-none-any.whl", hash = "sha256:71c77bd885d2ce44900731d4652d0d1c174dc66a0f11200e0c680bdedf1a6b37"},
-    {file = "mypy-0.920.tar.gz", hash = "sha256:a55438627f5f546192f13255a994d6d1cf2659df48adcf966132b4379fd9c86b"},
+    {file = "mypy-0.930-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:221cc94dc6a801ccc2be7c0c9fd791c5e08d1fa2c5e1c12dec4eab15b2469871"},
+    {file = "mypy-0.930-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:db3a87376a1380f396d465bed462e76ea89f838f4c5e967d68ff6ee34b785c31"},
+    {file = "mypy-0.930-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1d2296f35aae9802eeb1327058b550371ee382d71374b3e7d2804035ef0b830b"},
+    {file = "mypy-0.930-cp310-cp310-win_amd64.whl", hash = "sha256:959319b9a3cafc33a8185f440a433ba520239c72e733bf91f9efd67b0a8e9b30"},
+    {file = "mypy-0.930-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:45a4dc21c789cfd09b8ccafe114d6de66f0b341ad761338de717192f19397a8c"},
+    {file = "mypy-0.930-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1e689e92cdebd87607a041585f1dc7339aa2e8a9f9bad9ba7e6ece619431b20c"},
+    {file = "mypy-0.930-cp36-cp36m-win_amd64.whl", hash = "sha256:ed4e0ea066bb12f56b2812a15ff223c57c0a44eca817ceb96b214bb055c7051f"},
+    {file = "mypy-0.930-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a9d8dffefba634b27d650e0de2564379a1a367e2e08d6617d8f89261a3bf63b2"},
+    {file = "mypy-0.930-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b419e9721260161e70d054a15abbd50603c16f159860cfd0daeab647d828fc29"},
+    {file = "mypy-0.930-cp37-cp37m-win_amd64.whl", hash = "sha256:601f46593f627f8a9b944f74fd387c9b5f4266b39abad77471947069c2fc7651"},
+    {file = "mypy-0.930-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1ea7199780c1d7940b82dbc0a4e37722b4e3851264dbba81e01abecc9052d8a7"},
+    {file = "mypy-0.930-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:70b197dd8c78fc5d2daf84bd093e8466a2b2e007eedaa85e792e513a820adbf7"},
+    {file = "mypy-0.930-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5feb56f8bb280468fe5fc8e6f56f48f99aa0df9eed3c507a11505ee4657b5380"},
+    {file = "mypy-0.930-cp38-cp38-win_amd64.whl", hash = "sha256:2e9c5409e9cb81049bb03fa1009b573dea87976713e3898561567a86c4eaee01"},
+    {file = "mypy-0.930-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:554873e45c1ca20f31ddf873deb67fa5d2e87b76b97db50669f0468ccded8fae"},
+    {file = "mypy-0.930-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0feb82e9fa849affca7edd24713dbe809dce780ced9f3feca5ed3d80e40b777f"},
+    {file = "mypy-0.930-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:bc1a0607ea03c30225347334af66b0af12eefba018a89a88c209e02b7065ea95"},
+    {file = "mypy-0.930-cp39-cp39-win_amd64.whl", hash = "sha256:f9f665d69034b1fcfdbcd4197480d26298bbfb5d2dfe206245b6498addb34999"},
+    {file = "mypy-0.930-py3-none-any.whl", hash = "sha256:bf4a44e03040206f7c058d1f5ba02ef2d1820720c88bc4285c7d9a4269f54173"},
+    {file = "mypy-0.930.tar.gz", hash = "sha256:51426262ae4714cc7dd5439814676e0992b55bcc0f6514eccb4cf8e0678962c2"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -809,8 +809,8 @@ pathspec = [
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
 platformdirs = [
-    {file = "platformdirs-2.4.0-py3-none-any.whl", hash = "sha256:8868bbe3c3c80d42f20156f22e7131d2fb321f5bc86a2a345375c6481a67021d"},
-    {file = "platformdirs-2.4.0.tar.gz", hash = "sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2"},
+    {file = "platformdirs-2.4.1-py3-none-any.whl", hash = "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca"},
+    {file = "platformdirs-2.4.1.tar.gz", hash = "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 [tool.poe.tasks]
 serve = { cmd = "uvicorn karman:app --reload", help = "Runs a development instance" }
-test = { cmd = "pytest -n auto", help = "Run Tests" }
+test = { cmd = "pytest -n auto --doctest-modules", help = "Run Tests" }
 clean = { cmd = "rm -rf .mypy_cache .pytest_cache htmlcov coverage.xml .coverage", help = "Remove build and cache files" }
 [tool.poe.tasks.lint]
 sequence = [
@@ -61,6 +61,7 @@ warn_untyped_fields = true
 python = "^3.9"
 fastapi = "^0.70.1"
 fastapi-pagination = "^0.9.1"
+python-dotenv = "^0.19.2"
 # Uvicorn Optional Dependency
 uvicorn = { version = "^0.16.0", optional = true, extras = ["standard"] }
 # Pytest Optional Dependency
@@ -74,7 +75,7 @@ uvicorn = "^0.16.0"
 black = "^21.12b0"
 poethepoet = "^0.11.0"
 isort = "^5.10.1"
-mypy = "^0.920"
+mypy = "^0.930"
 flake8 = "^4.0.1"
 flake8-black = "^0.2.3"
 flake8-isort = "^4.1.1"


### PR DESCRIPTION
This PR improves settings handling for the backend application by making use of the Pydantic `BaseSettings` class. This allows us to read settings from multiple places easily:
- A JSON configuration file
- `.env` files
- Files from a directory (very useful for secrets)
- Environment variables

This makes it very easy to configure the application while generating almost no development overhead. Adding settings is as easy as adding a new field to `karman.config.Settings`. The rest is done automatically. It is even possible to support complex fields.

See the documentation on the class `karman.config.Settings` for some details.